### PR TITLE
RMSE instead of MAE

### DIFF
--- a/rescomp/ResComp.py
+++ b/rescomp/ResComp.py
@@ -253,7 +253,7 @@ class ResComp:
         self.is_trained = True
         # Compute error
         diff = self.W_out @ driven_states.T - true_states.T
-        error = np.mean(np.linalg.norm(diff, ord=2, axis=0))
+        error = np.mean(np.linalg.norm(diff, ord=2, axis=0)**2)**(1/2)
         if return_states:
             # Return node states
             return error, driven_states


### PR DESCRIPTION
It was about 4 keystrokes. I tried to make sure that it didn't add any errors, and it seemed to run fine. The square needs to be elementwise and the documentation on np.linalg.norm said it returns ndarray which works elementwise.